### PR TITLE
bump gitleaks image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zricethezav/gitleaks:v8.3.0
+FROM zricethezav/gitleaks:v8.17.0
 
 LABEL "com.github.actions.name"="gitleaks-action"
 LABEL "com.github.actions.description"="runs gitleaks on push and pull request events"


### PR DESCRIPTION
We're seeing the following error after updating `actions/checkout` to v3:
```
running gitleaks with the following command👇
gitleaks detect --source=/github/workspace --verbose --redact --log-opts=remotes/origin/master..HEAD

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks 

[8](https://github.com/invisible-tech/invisible/actions/runs/5283435664/jobs/9559667023?pr=5940#step:4:9):44PM ERR fatal: ambiguous argument 'remotes/origin/master..HEAD': unknown revision or path not in the working tree.
8:44PM ERR Use '--' to separate paths from revisions, like this:
8:44PM ERR 'git <command> [<revision>...] -- [<file>...]'
```

Let's see if it's fixed in a later version of gitleaks