### PR TITLE
fix: appease the git directory ownership check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="purple"
 LABEL "repository"="https://github.com/zricethezav/gitleaks-action"
 
+RUN git config --system --add safe.directory /github/workspace
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
I think we may have to use `--system` instead of `--global` because of https://github.com/actions/checkout/issues/1169.  This is the workaround I've seen others using, so maybe it will work...