### PR TITLE
Revert "fix: appease the git directory ownership check"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,5 @@ LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="purple"
 LABEL "repository"="https://github.com/zricethezav/gitleaks-action"
 
-RUN git config --system --add safe.directory /github/workspace
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Reverts invisible-tech/gitleaks-action#9

```
error: could not lock config file /etc/gitconfig: Permission denied
```

Continuing to investigate...  Seems like we shouldn't have to run this command ourselves anyway, because...

1. the checkout@v3 action [has](https://github.com/actions/checkout#usage) a default-true option to add the safe directory git config...
```
    # Add repository path as safe.directory for Git global config by running `git
    # config --global --add safe.directory <path>`
    # Default: true
    set-safe-directory: ''
```

2. the gitleaks docker image [has](https://hub.docker.com/layers/zricethezav/gitleaks/v8.17.0/images/sha256-99e40155529614d09d264cc886c1326c9a4593ad851ccbeaaed8dcf03ff3d3d7?context=explore) a RUN step to set it as well...
```
    RUN /bin/sh -c git config --global --add safe.directory '*' # buildkit
```

Working my way through the many comments on https://github.com/actions/runner-images/issues/6775